### PR TITLE
alcom fix filepicker

### DIFF
--- a/pkgs/by-name/al/alcom/package.nix
+++ b/pkgs/by-name/al/alcom/package.nix
@@ -15,6 +15,7 @@
   pkg-config,
   rustPlatform,
   stdenv,
+  wrapGAppsHook
   webkitgtk_4_1,
 }:
 let
@@ -60,6 +61,7 @@ rustPlatform.buildRustPackage {
     dotnetSdk
     nodejs
     npmHooks.npmConfigHook
+    wrapGAppsHook
     pkg-config
   ];
 

--- a/pkgs/by-name/al/alcom/package.nix
+++ b/pkgs/by-name/al/alcom/package.nix
@@ -15,7 +15,7 @@
   pkg-config,
   rustPlatform,
   stdenv,
-  wrapGAppsHook,
+  wrapGAppsHook4,
   webkitgtk_4_1,
 }:
 let
@@ -61,7 +61,7 @@ rustPlatform.buildRustPackage {
     dotnetSdk
     nodejs
     npmHooks.npmConfigHook
-    wrapGAppsHook
+    wrapGAppsHook4
     pkg-config
   ];
 

--- a/pkgs/by-name/al/alcom/package.nix
+++ b/pkgs/by-name/al/alcom/package.nix
@@ -15,7 +15,7 @@
   pkg-config,
   rustPlatform,
   stdenv,
-  wrapGAppsHook
+  wrapGAppsHook,
   webkitgtk_4_1,
 }:
 let


### PR DESCRIPTION
Fixes an error with the file picker in alcom:
"Settings schema 'org.gtk.Settings.FileChooser' is not installed"


<!--
^ Please summarise the changes you have done and explain why they are necessary here ^

For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->
Fixed an issue I've run into when using alcom on plasma 6, when I would try to set the location of Unityhub manually (Settings schema 'org.gtk.Settings.FileChooser' is not installed). Fixed by adding wrapGAppsHook to nativeBuildInputs

I have successfully built this on my Nixos Unstable 25.05 system